### PR TITLE
Correct JavaDocfor List Athlete Activities

### DIFF
--- a/Strava API v3/src/javastrava/api/v3/rest/API.java
+++ b/Strava API v3/src/javastrava/api/v3/rest/API.java
@@ -1576,9 +1576,9 @@ public class API {
 
 	/**
 	 * @param before
-	 *            Time in milliseconds since the UNIX epoch date - only return activities commenced before this time
+	 *            Time in seconds since the UNIX epoch date - only return activities commenced before this time
 	 * @param after
-	 *            Time in milliseconds since the UNIX epoch date - only return activities commenced after this time
+	 *            Time in seconds since the UNIX epoch date - only return activities commenced after this time
 	 * @param page
 	 *            Page number to return
 	 * @param perPage
@@ -1596,9 +1596,9 @@ public class API {
 
 	/**
 	 * @param before
-	 *            Time in milliseconds since the UNIX epoch date - only return activities commenced before this time
+	 *            Time in seconds since the UNIX epoch date - only return activities commenced before this time
 	 * @param after
-	 *            Time in milliseconds since the UNIX epoch date - only return activities commenced after this time
+	 *            Time in seconds since the UNIX epoch date - only return activities commenced after this time
 	 * @param page
 	 *            Page number to return
 	 * @param perPage


### PR DESCRIPTION
JavaDoc states before/after params are in milliseconds when they are actually seconds. Millis since 1970 wouldn't fit in an int now :)

http://strava.github.io/api/v3/activities/#get-activities