### PR TITLE
Fix for date time serializers

### DIFF
--- a/Strava API v3/src/javastrava/json/impl/gson/serializer/LocalDateTimeSerializer.java
+++ b/Strava API v3/src/javastrava/json/impl/gson/serializer/LocalDateTimeSerializer.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;

--- a/Strava API v3/src/javastrava/json/impl/gson/serializer/LocalDateTimeSerializer.java
+++ b/Strava API v3/src/javastrava/json/impl/gson/serializer/LocalDateTimeSerializer.java
@@ -23,7 +23,7 @@ public class LocalDateTimeSerializer implements JsonSerializer<LocalDateTime>, J
 	 */
 	@Override
 	public JsonElement serialize(final LocalDateTime src, final Type srcType, final JsonSerializationContext context) {
-		return new JsonPrimitive(src.atZone(ZoneOffset.UTC).toString());
+		return new JsonPrimitive(src.atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));
 	}
 
 	/**

--- a/Strava API v3/src/javastrava/json/impl/gson/serializer/ZonedDateTimeSerializer.java
+++ b/Strava API v3/src/javastrava/json/impl/gson/serializer/ZonedDateTimeSerializer.java
@@ -2,6 +2,7 @@ package javastrava.json.impl.gson.serializer;
 
 import java.lang.reflect.Type;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;

--- a/Strava API v3/src/javastrava/json/impl/gson/serializer/ZonedDateTimeSerializer.java
+++ b/Strava API v3/src/javastrava/json/impl/gson/serializer/ZonedDateTimeSerializer.java
@@ -21,7 +21,7 @@ public class ZonedDateTimeSerializer implements JsonSerializer<ZonedDateTime>, J
 	 */
 	@Override
 	public JsonElement serialize(final ZonedDateTime src, final Type srcType, final JsonSerializationContext context) {
-		return new JsonPrimitive(src.toString());
+		return new JsonPrimitive(src.format(DateTimeFormatter.ISO_DATE_TIME));
 	}
 
 	/**


### PR DESCRIPTION
Hi, 

I'm working on a project that will make a daily request for my list of KOMs and compare that with the list of KOMs from the previous day. If a new KOM gets created and I happen to be first on the new segment, then the service will send an email with any new KOMs gained since the previous day.

The list of KOMs from day to day is saved in a file in JSON format. I'm using the JSON serializer classes to do this. However I have some KOMs where the start_date and start_date_local have 0 seconds (eg. 2016-08-07T08:58:00Z). The current implementation uses .toString() to save the times in JSON and this means the seconds part of the time gets truncated (eg. 2016-08-07T08:58Z) This becomes a problem when deserializing the JSON as the seconds part is required.

My solution would be to format the date time objects to make sure the full time string is saved in the JSON file even if it is 0 seconds. This allows deserialization to work as it should.

Thanks,
Kevin