### PR TITLE
#190: changed upload_id from int to long

### DIFF
--- a/Strava API v3/src/javastrava/api/v3/model/StravaActivity.java
+++ b/Strava API v3/src/javastrava/api/v3/model/StravaActivity.java
@@ -308,7 +308,7 @@ public class StravaActivity implements StravaCacheable<Integer>{
 	/**
 	 * Identifier of the original upload
 	 */
-	private Integer uploadId;
+	private Long uploadId;
 
 	/**
 	 * Latitude of the start point of the activity
@@ -971,7 +971,7 @@ public class StravaActivity implements StravaCacheable<Integer>{
 	/**
 	 * @return the uploadId
 	 */
-	public Integer getUploadId() {
+	public Long getUploadId() {
 		return this.uploadId;
 	}
 	/**
@@ -1381,7 +1381,7 @@ public class StravaActivity implements StravaCacheable<Integer>{
 	/**
 	 * @param uploadId the uploadId to set
 	 */
-	public void setUploadId(final Integer uploadId) {
+	public void setUploadId(final Long uploadId) {
 		this.uploadId = uploadId;
 	}
 	/**


### PR DESCRIPTION
fix: java.lang.NumberFormatException
   Expected an int but was 2149769579 at line 1 column 292 path $[0].upload_id